### PR TITLE
Add storage cookie setting helpers for path and domain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kinde-oss/kinde-auth-php",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Kinde PHP SDK for authentication",
   "license": "MIT",
   "keywords": [

--- a/lib/Sdk/Storage/BaseStorage.php
+++ b/lib/Sdk/Storage/BaseStorage.php
@@ -8,6 +8,8 @@ class BaseStorage
 {
     static $prefix = 'kinde';
     static $storage;
+    private static $cookiePath = "";
+    private static $cookieDomain = "";
 
     static function getStorage()
     {
@@ -26,14 +28,14 @@ class BaseStorage
         string $key,
         string $value,
         int $expires_or_options = 0,
-        string $path = "",
-        string $domain = "",
+        string $path = null,
+        string $domain = null,
         bool $secure = true,
         bool $httpOnly = false
     ) {
         $newKey = self::getKey($key);
         $_COOKIE[$newKey] = $value;
-        setcookie($newKey, $value, $expires_or_options, $path, $domain, $secure, $httpOnly);
+        setcookie($newKey, $value, $expires_or_options, $path ?? self::$cookiePath, $domain ?? self::$cookieDomain, $secure, $httpOnly);
     }
 
     public static function removeItem(string $key)
@@ -57,5 +59,15 @@ class BaseStorage
     private static function getKey($key)
     {
         return self::$prefix . '_' . $key;
+    }
+
+    public static function setCookiePath($cookiePath)
+    {
+        self::$cookiePath = $cookiePath;
+    }
+
+    public static function setCookieDomain($cookieDomain)
+    {
+        self::$cookieDomain = $cookieDomain;
     }
 }


### PR DESCRIPTION
# Explain your changes

Add helpers for setting the cookie path and domain in the storage class. This allows the code to be called from a subdirectory but the cookie can be applied to the whole domain and / or subdomains. 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
