### PR TITLE
Fix default value of JWT cookie path

### DIFF
--- a/lib/Sdk/Storage/BaseStorage.php
+++ b/lib/Sdk/Storage/BaseStorage.php
@@ -26,7 +26,7 @@ class BaseStorage
         string $key,
         string $value,
         int $expires_or_options = 0,
-        string $path = "",
+        string $path = "/",
         string $domain = "",
         bool $secure = true,
         bool $httpOnly = false


### PR DESCRIPTION
Hi

I have a login URL of /login and a callback url of /auth/callback

in this scenario, the kinde_token jwt is created with the cooki path /auth

This means that when I access my profile user data with /profile it doesnt find the JWT.
if i would use /auth/profile it would work

the reason is because of the optional path argument with default of an empty string,
i think this should be "/" as default, could that be?

then it works