### PR TITLE
Fix reading of feature flags

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -433,13 +433,16 @@ class KindeClientSDK
                 'v' => $options['defaultValue'],
                 't' => $flagType
             ];
+        } else {
+            # this read the value from the existing flag
+            $flagType = $flag['t'];
         }
 
         if (!isset($flag['v'])) {
             throw new UnexpectedValueException("This flag '{$flagName}' was not found, and no default value has been provided");
         }
 
-        $flagTypeParsed = Utils::$listType[$flag['t']];
+        $flagTypeParsed = Utils::$listType[$flagType];
 
         $requestType = Utils::$listType[$flagType];
         if (isset($requestType) && $flagTypeParsed != $requestType) {


### PR DESCRIPTION
Hi

so it's a bit weird (after a few PRs now)
I wanted to read an existing feature flag and got another array access error

Then i figured out that the $flagType variable is not set if a flag is correctly found
this leads to an error in 

$requestType = Utils::$listType[$flagType];

so i did add a default else-way for existing flags

and I also changed the other $flag['t'] access...because it can be provided as argument (but i dont know the impact)
