### PR TITLE
Add storage cookie setting helpers for httpOnly

### DIFF
--- a/lib/Sdk/Storage/BaseStorage.php
+++ b/lib/Sdk/Storage/BaseStorage.php
@@ -8,7 +8,7 @@ class BaseStorage
 {
     static $prefix = 'kinde';
     static $storage;
-    private static $cookieHttpOnly = false;
+    private static $cookieHttpOnly = true;
     private static $cookiePath = "/";
     private static $cookieDomain = "";
 


### PR DESCRIPTION
# Explain your changes

Addon to #27. To prevent XSS SDK should default to http only as being set to true. For specific applications that understand the additional risk and have requirements that need to utilize this then present them with the option for it to be disabled via   
$storage->setCookieHttpOnly(true or false);
This is inline with the new proposed implementation of #27 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced an option to configure HTTP-only cookies in storage settings for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->