### PR TITLE
Add additional helpers for token decoding

### DIFF
--- a/lib/Sdk/Storage/Storage.php
+++ b/lib/Sdk/Storage/Storage.php
@@ -98,6 +98,20 @@ class Storage extends BaseStorage
         ];
     }
 
+    static function getDecodedIdToken()
+    {
+        $token = self::getToken();
+        $payload = Utils::parseJWT($token['id_token'] ?? '');
+        return $payload;
+    }
+
+    static function getDecodedAccessToken()
+    {
+        $token = self::getToken();
+        $payload = Utils::parseJWT($token['access_token'] ?? '');
+        return $payload;
+    }
+
     static function getJwksUrl()
     {
         return self::getItem(StorageEnums::JWKS_URL);


### PR DESCRIPTION
# Explain your changes

The id_token and access_token supports custom properties set via Kinde and when we need to access several properties simultaneously and repeatedly, decoding each property individually with getClaim is inefficient due to each JWT decode that needs to take place with n claims or properties. Currently, there doesn't appear to be any function that decodes the entire token at once.

This pull request introduces two additional functions that allows for the decoding of the entire id_token or access_token in one go. This enables the retrieval of custom properties via PHP, eliminating the necessity for repeated JWT decoding as well as any additional checks or manipulation that needs to be done based on token data.

An additional solution could be to also allow getClaim to accept an array instead of single keys.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
