### PR TITLE
Return associative array from parseJWT

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -430,6 +430,7 @@ class KindeClientSDK
     {
         $isUsedDefault = false;
         $flag = self::getFeatureFlags($flagName);
+        
         if (!isset($flag)) {
             $isUsedDefault = true;
             $flag = [
@@ -441,10 +442,9 @@ class KindeClientSDK
         if (!isset($flag['v'])) {
             throw new UnexpectedValueException("This flag '{$flagName}' was not found, and no default value has been provided");
         }
-
         $flagTypeParsed = Utils::$listType[$flag['t']];
 
-        $requestType = Utils::$listType[$flagType];
+        $requestType = $flagType ? Utils::$listType[$flagType] : null;
         if (isset($requestType) && $flagTypeParsed != $requestType) {
             throw new UnexpectedValueException("Flag '{$flagName}' is type {$flagTypeParsed} - requested type {$requestType}");
         }

--- a/lib/Sdk/Utils/Utils.php
+++ b/lib/Sdk/Utils/Utils.php
@@ -101,7 +101,7 @@ class Utils
             $jwks_json = file_get_contents($jwks_url);
             $jwks = json_decode($jwks_json, true);
 
-            return (array) JWT::decode($token, JWK::parseKeySet($jwks));
+            return json_decode(json_encode(JWT::decode($token, JWK::parseKeySet($jwks))), true);
         } catch (Exception $e) {
             return null;
         }


### PR DESCRIPTION
# Explain your changes

The new firebase library JWT:decode function is returning an object, whereas previously the parseJWT function was expected to return an associate array, the (array) casting is only casting the top level which is causing bugs elsewhere, e.g. the getFeatureFlags function expects flags to be an array. 

Also accounted for $flagType being empty when using the getFlag function.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
