### PR TITLE
Prevent expiry check error when the token fails decoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kinde-oss/kinde-auth-php",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Kinde PHP SDK for authentication",
   "license": "MIT",
   "keywords": [

--- a/lib/Sdk/Storage/Storage.php
+++ b/lib/Sdk/Storage/Storage.php
@@ -52,9 +52,17 @@ class Storage extends BaseStorage
     static function getExpiredAt()
     {
         $accessToken = self::getAccessToken();
-        if (empty($accessToken)) return 0;
-        $parsedToken = Utils::parseJWT($accessToken);
-        return empty($parsedToken) ? 0 : $parsedToken['exp'];
+
+        if (empty($accessToken)) {
+            return 0;
+        } else {
+            $parsedToken = Utils::parseJWT($accessToken);
+            if (empty($parsedToken)) {
+                return 0;
+            } else {
+                return $parsedToken['exp'];
+            }
+        }
     }
 
     static function getTokenTimeToLive()

--- a/lib/Sdk/Storage/Storage.php
+++ b/lib/Sdk/Storage/Storage.php
@@ -52,7 +52,9 @@ class Storage extends BaseStorage
     static function getExpiredAt()
     {
         $accessToken = self::getAccessToken();
-        return empty($accessToken) ? 0 : Utils::parseJWT($accessToken)['exp'];
+        if (empty($accessToken)) return 0;
+        $parsedToken = Utils::parseJWT($accessToken);
+        return empty($parsedToken) ? 0 : $parsedToken['exp'];
     }
 
     static function getTokenTimeToLive()


### PR DESCRIPTION
# Explain your changes

When the token has expired parseJWT will return null, resulting in a warning in the getExpiredAt function as $parsedToken is not defined. Fix by checking if it parsed correctly first.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the reliability of token expiration checks by ensuring non-empty access tokens are parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->