### PR TITLE
security: Removed client token from store.

### DIFF
--- a/lib/Sdk/OAuth2/ClientCredentials.php
+++ b/lib/Sdk/OAuth2/ClientCredentials.php
@@ -48,7 +48,6 @@ class ClientCredentials
                     'form_params' => $formData
                 ]);
             $token = $response->getBody()->getContents();
-            $this->storage->setToken($token);
             return json_decode($token);
         } catch (\Throwable $th) {
             throw $th;


### PR DESCRIPTION
# Explain your changes

This change removes the setting of the client credentials in both $_COOKIE store. The user will now have to re-authenticate each time they need this token.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
