### PR TITLE
Remove JWKS url from storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kinde-oss/kinde-auth-php",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "description": "Kinde PHP SDK for authentication",
   "license": "MIT",
   "keywords": [

--- a/lib/Sdk/Enums/StorageEnums.php
+++ b/lib/Sdk/Enums/StorageEnums.php
@@ -13,6 +13,4 @@ class StorageEnums
     const AUTH_STATUS = 'auth_status';
 
     const USER_PROFILE = 'user_profile';
-
-    const JWKS_URL = 'jwks_url';
 }

--- a/lib/Sdk/Storage/Storage.php
+++ b/lib/Sdk/Storage/Storage.php
@@ -8,7 +8,7 @@ use Kinde\KindeSDK\Sdk\Utils\Utils;
 class Storage extends BaseStorage
 {
     public static $instance;
-
+    private static $jwksUrl;
     private static $tokenTimeToLive;
 
     public static function getInstance()
@@ -124,11 +124,15 @@ class Storage extends BaseStorage
 
     static function getJwksUrl()
     {
-        return self::getItem(StorageEnums::JWKS_URL);
+        if (!self::$jwksUrl) {
+          throw new \LogicException('No jwks url has been specified');
+        };
+
+        return self::$jwksUrl;
     }
 
     static function setJwksUrl($jwksUrl)
     {
-        return self::setItem(StorageEnums::JWKS_URL, $jwksUrl);
+        self::$jwksUrl = $jwksUrl;
     }
 }

--- a/lib/Sdk/Storage/Storage.php
+++ b/lib/Sdk/Storage/Storage.php
@@ -126,7 +126,7 @@ class Storage extends BaseStorage
     {
         if (!self::$jwksUrl) {
           throw new \LogicException('No jwks url has been specified');
-        };
+        }
 
         return self::$jwksUrl;
     }


### PR DESCRIPTION
# Explain your changes

Remove JWKS url from storage.

# Backward incompatible changes

Calling the Kinde\KindeSDK\Sdk\Storage\Storage helper functions without instantiating the kinde client first. This can be resolved by either instantiating the Kinde client or setting the JWKS url using the setJwksUrl function first.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
