### PR TITLE
M2M conflict fix - only clear cookie storage for relevant grant types

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -152,16 +152,17 @@ class KindeClientSDK
     public function login(
         array $additionalParameters = []
     ) {
-        $this->cleanStorage();
         try {
             switch ($this->grantType) {
                 case GrantType::clientCredentials:
                     $auth = new ClientCredentials();
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::authorizationCode:
+                    $this->cleanStorage();
                     $auth = new AuthorizationCode();
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::PKCE:
+                    $this->cleanStorage();
                     $auth = new PKCE();
                     return $auth->authenticate($this, 'login', $additionalParameters);
                 default:


### PR DESCRIPTION
# Explain your changes

Simple hotfix to remove machine-to-machine (m2m) conflict where using the API is clearing user cookies. The client credentials grant type does not use cookie storage or the cleared values. The update only clears the storage for relevant grant types (Authorization Code and PKCE). 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
