### PR TITLE
re-auth added in line with js-utils

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -248,7 +248,7 @@ class KindeClientSDK
         
         $error = $params['error'] ?? '';
         
-        // Handle login_link_expired with reauth_state (like Next.js implementation)
+
         if (strtolower($error) === 'login_link_expired') {
             $reauthState = $params['reauth_state'] ?? '';
             
@@ -257,7 +257,7 @@ class KindeClientSDK
                     $reauthParams = Utils::processReauthState($reauthState);
                     
                     $this->login($reauthParams);
-                    return null; // Will redirect
+                    return null; 
                     
                 } catch (Exception $e) {
                     throw new InvalidArgumentException('Error parsing reauth state: ' . $e->getMessage());

--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -697,4 +697,31 @@ class KindeClientSDK
             throw new Exception('Failed to fetch profile URL: ' . $e->getMessage());
         }
     }
+
+    /**
+     * Force re-authentication 
+     * @param array $additionalParameters Additional parameters
+     * @return mixed Authentication result
+     */
+    public function reAuthenticate(array $additionalParameters = [])
+    {
+        $additionalParameters['prompt'] = PromptTypes::LOGIN;
+        return $this->login($additionalParameters);
+    }
+
+    /**
+     * Create reauth state from current configuration
+     * @param array $additionalParams Additional parameters to preserve
+     * @return string Base64 encoded reauth state
+     */
+    public function createReauthState(array $additionalParams = []): string
+    {
+        $state = array_merge([
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->redirectUri,
+            'scope' => $this->scopes,
+        ], $additionalParams);
+        
+        return base64_encode(json_encode($state));
+    }
 }

--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -10,6 +10,7 @@ use Kinde\KindeSDK\Sdk\Enums\GrantType;
 use Kinde\KindeSDK\Sdk\Enums\StorageEnums;
 use Kinde\KindeSDK\Sdk\Enums\TokenType;
 use Kinde\KindeSDK\Sdk\Enums\PortalPage;
+use Kinde\KindeSDK\Sdk\Enums\PromptTypes;
 use Kinde\KindeSDK\Sdk\OAuth2\AuthorizationCode;
 use Kinde\KindeSDK\Sdk\OAuth2\ClientCredentials;
 use Kinde\KindeSDK\Sdk\Utils\Utils;
@@ -710,7 +711,7 @@ class KindeClientSDK
     }
 
     /**
-     * Create reauth state from current configuration
+     * Creates re-authentication state from current configuration
      * @param array $additionalParams Additional parameters to preserve
      * @return string Base64 encoded reauth state
      */
@@ -722,6 +723,11 @@ class KindeClientSDK
             'scope' => $this->scopes,
         ], $additionalParams);
         
-        return base64_encode(json_encode($state));
+        $json = json_encode($state);
+        if ($json === false) {
+            throw new InvalidArgumentException('Failed to encode reauth state: ' . json_last_error_msg());
+        }
+        
+        return base64_encode($json);
     }
 }

--- a/lib/Sdk/Enums/AdditionalParameters.php
+++ b/lib/Sdk/Enums/AdditionalParameters.php
@@ -13,6 +13,9 @@ class AdditionalParameters
         'connection_id' => 'string',
         'lang' => 'string',
         'plan_interest' => 'string',
-        'pricing_table_key' => 'string'
+        'pricing_table_key' => 'string',
+        'prompt' => 'string',
+        'reauth_state' => 'string',
+        'supports_reauth' => 'string'
     ];
 }

--- a/lib/Sdk/Enums/PromptTypes.php
+++ b/lib/Sdk/Enums/PromptTypes.php
@@ -1,0 +1,9 @@
+<?php
+namespace Kinde\KindeSDK\Sdk\Enums;
+
+class PromptTypes 
+{
+    const NONE = 'none';
+    const CREATE = 'create';
+    const LOGIN = 'login'; 
+}

--- a/lib/Sdk/OAuth2/PKCE.php
+++ b/lib/Sdk/OAuth2/PKCE.php
@@ -30,6 +30,17 @@ class PKCE
      */
     public function authenticate(KindeClientSDK $clientSDK, string $startPage = 'login', array $additionalParameters = [])
     {
+        // Handle reauth_state if present (using existing processReauthState function)
+        if (isset($additionalParameters['reauth_state'])) {
+            try {
+                $reauthParams = Utils::processReauthState($additionalParameters['reauth_state']);
+                $additionalParameters = array_merge($reauthParams, $additionalParameters);
+                unset($additionalParameters['reauth_state']);
+            } catch (Exception $e) {
+                throw new InvalidArgumentException($e->getMessage());
+            }
+        }
+
         $this->storage->removeItem(StorageEnums::CODE_VERIFIER);
         $challenge = Utils::generateChallenge();
         $state = $challenge['state'];

--- a/lib/Sdk/Utils/Utils.php
+++ b/lib/Sdk/Utils/Utils.php
@@ -185,4 +185,29 @@ class Utils
         }
         return $target;
     }
+
+    /**
+     * Processes re-authentication state parameter
+     * @param string $reauthState Base64 encoded re-auth parameters  
+     * @return array Decoded parameters (already in snake_case)
+     * @throws InvalidArgumentException On invalid input
+     */
+    static public function processReauthState(string $reauthState): array
+    {
+        try {
+            $decoded = base64_decode($reauthState, true);
+            if ($decoded === false) {
+                throw new InvalidArgumentException('Invalid base64 reauth_state');
+            }
+            
+            $params = json_decode($decoded, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new InvalidArgumentException('Invalid JSON in reauth_state: ' . json_last_error_msg());
+            }
+            
+            return $params;
+        } catch (Exception $e) {
+            throw new InvalidArgumentException('Error handling reauth state: ' . $e->getMessage());
+        }
+    }
 }

--- a/lib/Sdk/Utils/Utils.php
+++ b/lib/Sdk/Utils/Utils.php
@@ -206,9 +206,9 @@ class Utils
                 throw new InvalidArgumentException('Invalid JSON in reauth_state: ' . json_last_error_msg());
             }
             
-            return $params; // No conversion needed - PHP uses snake_case
+            return $params; 
         } catch (InvalidArgumentException $e) {
-            throw $e; // Re-throw specific validation errors as-is
+            throw $e; 
         } catch (Exception $e) {
             throw new InvalidArgumentException('Error handling reauth state: ' . $e->getMessage());
         }

--- a/lib/Sdk/Utils/Utils.php
+++ b/lib/Sdk/Utils/Utils.php
@@ -8,6 +8,7 @@ use Kinde\KindeSDK\Sdk\Storage\Storage;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use Exception;
+use Kinde\KindeSDK\Sdk\Enums\PromptTypes;
 
 class Utils
 {
@@ -205,7 +206,9 @@ class Utils
                 throw new InvalidArgumentException('Invalid JSON in reauth_state: ' . json_last_error_msg());
             }
             
-            return $params;
+            return $params; // No conversion needed - PHP uses snake_case
+        } catch (InvalidArgumentException $e) {
+            throw $e; // Re-throw specific validation errors as-is
         } catch (Exception $e) {
             throw new InvalidArgumentException('Error handling reauth state: ' . $e->getMessage());
         }


### PR DESCRIPTION
### Summary
Implements re-authentication functionality to match js-utils SDK capabilities, enabling forced user re-authentication and authentication state preservation.

## Changes

- Added PromptTypes enum - Includes LOGIN, CREATE, NONE constants for authentication prompts
- Enhanced AdditionalParameters - Added support for prompt, reauth_state, supports_reauth parameters
- Added Utils::processReauthState() - Decodes and processes base64-encoded re-authentication state
- Enhanced PKCE::authenticate() - Handles reauth_state parameter processing and merging
- Added KindeClientSDK::createReauthState() - Creates base64-encoded authentication state for preservation
- Added KindeClientSDK::reAuthenticate() - Convenience method for forced re-authentication


## Note

I have not worked a massive amount in php so any feedback or optimizations would be greatly appreciated. 
