### PR TITLE
feat: remove deprecated start_page and add prompt parameter support

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -184,12 +184,18 @@ class KindeClientSDK
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::authorizationCode:
                     $this->cleanStorage();
+                    if (!isset($additionalParameters['prompt'])) {
+                        $additionalParameters['prompt'] = 'login';
+                    }
                     $auth = new AuthorizationCode();
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::PKCE:
                     $this->cleanStorage();
+                    if (!isset($additionalParameters['prompt'])) {
+                        $additionalParameters['prompt'] = 'login';
+                    }
                     $auth = new PKCE();
-                    return $auth->authenticate($this, 'login', $additionalParameters);
+                    return $auth->authenticate($this, $additionalParameters);
                 default:
                     throw new InvalidArgumentException("Please provide correct grant_type");
                     break;
@@ -210,8 +216,12 @@ class KindeClientSDK
     {
         $this->grantType = 'authorization_code';
 
+        if (!isset($additionalParameters['prompt'])) {
+            $additionalParameters['prompt'] = 'register';
+        }
+
         $auth = new PKCE();
-        return $auth->authenticate($this, 'registration', $additionalParameters);
+        return $auth->authenticate($this, $additionalParameters);
     }
 
     /**

--- a/lib/Sdk/Enums/AdditionalParameters.php
+++ b/lib/Sdk/Enums/AdditionalParameters.php
@@ -13,6 +13,7 @@ class AdditionalParameters
         'connection_id' => 'string',
         'lang' => 'string',
         'plan_interest' => 'string',
-        'pricing_table_key' => 'string'
+        'pricing_table_key' => 'string',
+        'prompt' => 'string'
     ];
 }

--- a/lib/Sdk/OAuth2/AuthorizationCode.php
+++ b/lib/Sdk/OAuth2/AuthorizationCode.php
@@ -38,7 +38,6 @@ class AuthorizationCode
             'response_type' => 'code',
             'scope' => $clientSDK->scopes,
             'state' => $state,
-            'start_page' => 'login',
             'supports_reauth' => 'true',
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);

--- a/lib/Sdk/OAuth2/PKCE.php
+++ b/lib/Sdk/OAuth2/PKCE.php
@@ -23,12 +23,11 @@ class PKCE
      * Initiates the authentication process for the Kinde client SDK.
      *
      * @param KindeClientSDK $clientSDK           The Kinde client SDK instance.
-     * @param string         $startPage           The start page for the authentication process (default: 'login').
      * @param array          $additionalParameters An associative array of additional parameters (optional).
      *
      * @return void
      */
-    public function authenticate(KindeClientSDK $clientSDK, string $startPage = 'login', array $additionalParameters = [])
+    public function authenticate(KindeClientSDK $clientSDK, array $additionalParameters = [])
     {
         $this->storage->removeItem(StorageEnums::CODE_VERIFIER);
         $challenge = Utils::generateChallenge();
@@ -41,8 +40,7 @@ class PKCE
             'scope' => $clientSDK->scopes,
             'code_challenge' => $challenge['codeChallenge'],
             'code_challenge_method' => 'S256',
-            'state' => $state,
-            'start_page' => $startPage
+            'state' => $state
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);

--- a/test/Sdk/Enums/AdditionalParameters.php
+++ b/test/Sdk/Enums/AdditionalParameters.php
@@ -8,6 +8,7 @@ class AdditionalParameters
         'audience' => 'string',
         'org_code' => 'string',
         'org_name' => 'string',
-        'is_create_org' => 'string'
+        'is_create_org' => 'string',
+        'prompt' => 'string'
     ];
 }

--- a/test/Sdk/KindeClientSDK.php
+++ b/test/Sdk/KindeClientSDK.php
@@ -156,11 +156,17 @@ class KindeClientSDK
                     $auth = new ClientCredentials();
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::authorizationCode:
+                    if (!isset($additionalParameters['prompt'])) {
+                        $additionalParameters['prompt'] = 'login';
+                    }
                     $auth = new AuthorizationCode();
                     return $auth->authenticate($this, $additionalParameters);
                 case GrantType::PKCE:
+                    if (!isset($additionalParameters['prompt'])) {
+                        $additionalParameters['prompt'] = 'login';
+                    }
                     $auth = new PKCE();
-                    return $auth->authenticate($this, 'login', $additionalParameters);
+                    return $auth->authenticate($this, $additionalParameters);
                 default:
                     throw new InvalidArgumentException("Please provide correct grant_type");
                     break;
@@ -172,7 +178,7 @@ class KindeClientSDK
 
     /**
      * It redirects the user to the authorization endpoint with the client id, redirect uri, a random
-     * state, and the start page set to registration
+     * state, and the prompt set to register
      *
      * @param array additionalParameters The array includes params to pass api.
      */
@@ -180,8 +186,12 @@ class KindeClientSDK
     {
         $this->grantType = 'authorization_code';
 
+        if (!isset($additionalParameters['prompt'])) {
+            $additionalParameters['prompt'] = 'register';
+        }
+
         $auth = new PKCE();
-        return $auth->authenticate($this, 'registration', $additionalParameters);
+        return $auth->authenticate($this, $additionalParameters);
     }
 
     /**

--- a/test/Sdk/OAuth2/AuthorizationCode.php
+++ b/test/Sdk/OAuth2/AuthorizationCode.php
@@ -29,8 +29,7 @@ class AuthorizationCode
             'redirect_uri' => $clientSDK->redirectUri,
             'response_type' => 'code',
             'scope' => $clientSDK->scopes,
-            'state' => $state,
-            'start_page' => 'login'
+            'state' => $state
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);

--- a/test/Sdk/OAuth2/PKCE.php
+++ b/test/Sdk/OAuth2/PKCE.php
@@ -34,7 +34,7 @@ class PKCE
      * @return A redirect to the authorization endpoint with the parameters needed to start the
      * authorization process.
      */
-    public function authenticate(KindeClientSDK $clientSDK, string $startPage = 'login', array $additionalParameters = [])
+    public function authenticate(KindeClientSDK $clientSDK, array $additionalParameters = [])
     {
         $this->storage->removeItem(StorageEnums::CODE_VERIFIER);
         $challenge = Utils::generateChallenge();
@@ -47,8 +47,7 @@ class PKCE
             'scope' => $clientSDK->scopes,
             'code_challenge' => $challenge['codeChallenge'],
             'code_challenge_method' => 'S256',
-            'state' => $state,
-            'start_page' => $startPage
+            'state' => $state
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);


### PR DESCRIPTION
Here's a concise description for your PR:

## Explain your changes

This PR removes the deprecated `start_page` parameter and adds proper `prompt` parameter support to enable organization switching without reauthentication.

**Key changes:**
- Removed `start_page` from `PKCE::authenticate()` and `AuthorizationCode::authenticate()` methods
- Added `prompt` parameter to `AdditionalParameters` enum
- Updated `login()` to default to `prompt=login` and `register()` to default to `prompt=register`
- Enables silent authentication via `prompt=none` for seamless organization switching

**Customer impact:** Resolves issue where customers couldn't perform organization switching without forcing users to reauthenticate, as they were unable to pass `prompt=none` for silent authentication flows.

**Usage:**
```php
// Silent org switching (no reauthentication required)
$kindeClient->login(['org_code' => 'target_org', 'prompt' => 'none']);
```

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
