### PR TITLE
Fix: prevent TypeError when callback state is missing; accept nullabl…

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -834,15 +834,15 @@ class KindeClientSDK
     /**
      * Checks the authentication state against the provided state from the server.
      *
-     * @param string $stateServer The state received from the server.
+     * @param string|null $stateServer The state received from the server, or null if missing.
      *
      * @throws OAuthException If the authentication state is empty or does not match the provided state.
      */
-    private function checkStateAuthentication(string $stateServer)
+    private function checkStateAuthentication(?string $stateServer)
     {
         $storageOAuthState = $this->storage->getState();
 
-        if (empty($storageOAuthState) || $stateServer != $storageOAuthState) {
+        if (empty($stateServer) || empty($storageOAuthState) || $stateServer !== $storageOAuthState) {
             throw new OAuthException("Authentication failed because it tries to validate state");
         }
     }

--- a/test/Sdk/KindeClientSDK.php
+++ b/test/Sdk/KindeClientSDK.php
@@ -506,11 +506,11 @@ class KindeClientSDK
         return isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
     }
 
-    private function checkStateAuthentication(string $stateServer)
+    private function checkStateAuthentication(?string $stateServer)
     {
         $storageOAuthState = $this->storage->getState();
 
-        if (empty($storageOAuthState) || $stateServer != $storageOAuthState) {
+        if (empty($stateServer) || empty($storageOAuthState) || $stateServer !== $storageOAuthState) {
             throw new OAuthException("Authentication failed because it tries to validate state");
         }
     }


### PR DESCRIPTION
### Explain your changes

- Handle missing callback state gracefully: `checkStateAuthentication` now accepts `?string` and throws `OAuthException` when state is missing/empty or mismatched, preventing the fatal TypeError seen when bots/crawlers hit `/callback` without a `state`.

Files:
- `lib/KindeClientSDK.php`
- `test/Sdk/KindeClientSDK.php`

### Checklist

- [x] I have read the “Pull requests” section in the contributing guidelines.
- [x] I agree to the terms within the code of conduct.