### PR TITLE
Fix PHP 8.1+ deprecation warning: exit() passing null

### DIFF
--- a/lib/Sdk/OAuth2/AuthorizationCode.php
+++ b/lib/Sdk/OAuth2/AuthorizationCode.php
@@ -46,7 +46,8 @@ class AuthorizationCode
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);
         if (!headers_sent()) {
-            exit(header('Location: ' . $clientSDK->authorizationEndpoint . '?' . http_build_query($searchParams)));
+            header('Location: ' . $clientSDK->authorizationEndpoint . '?' . http_build_query($searchParams));
+            exit();
         }
     }
 }

--- a/lib/Sdk/OAuth2/PKCE.php
+++ b/lib/Sdk/OAuth2/PKCE.php
@@ -47,7 +47,8 @@ class PKCE
         $this->storage->setCodeVerifier($challenge['codeVerifier']);
 
         if (!headers_sent()) {
-            exit(header('Location: ' . $clientSDK->authorizationEndpoint . '?' . http_build_query($searchParams)));
+            header('Location: ' . $clientSDK->authorizationEndpoint . '?' . http_build_query($searchParams));
+            exit();
         }
     }
 }


### PR DESCRIPTION
##Description

Fixes https://github.com/kinde-oss/kinde-php-sdk/issues/72

Resolves the PHP 8.1+ deprecation warning exit(): Passing null to parameter #1 ($status) of type string|int is deprecated that occurs during OAuth authentication redirects.


##Files Changed 

lib/Sdk/OAuth2/AuthorizationCode.php
lib/Sdk/OAuth2/PKCE.php
