### PR TITLE
invitation_code functionality implementation 

### DIFF
--- a/lib/Frameworks/CodeIgniter/KindeAuthController.php
+++ b/lib/Frameworks/CodeIgniter/KindeAuthController.php
@@ -40,9 +40,15 @@ class KindeAuthController extends Controller
     public function login()
     {
         $additionalParams = array_filter(
-            $this->request->getGet(['org_code', 'org_name', 'is_create_org']),
+            $this->request->getGet(['org_code', 'org_name', 'is_create_org', 'invitation_code']),
             function($v) { return $v !== null && $v !== ''; }
         );
+        
+        // When invitation_code is present, use registration flow
+        if (!empty($additionalParams['invitation_code']) && !isset($additionalParams['prompt'])) {
+            $additionalParams['prompt'] = 'create';
+        }
+        
         try {
             $result = $this->kindeClient->login($additionalParams);
             $authUrl = $result->getAuthUrl();
@@ -119,7 +125,7 @@ class KindeAuthController extends Controller
     public function register()
     {
         $additionalParams = array_filter(
-            $this->request->getGet(['org_code', 'org_name', 'is_create_org']),
+            $this->request->getGet(['org_code', 'org_name', 'is_create_org', 'invitation_code']),
             function($v) { return $v !== null && $v !== ''; }
         );
         

--- a/lib/Frameworks/Laravel/Controllers/KindeAuthController.php
+++ b/lib/Frameworks/Laravel/Controllers/KindeAuthController.php
@@ -26,7 +26,12 @@ class KindeAuthController extends Controller
      */
     public function login(Request $request): RedirectResponse
     {
-        $additionalParams = $request->only(['org_code', 'org_name', 'is_create_org']);
+        $additionalParams = $request->only(['org_code', 'org_name', 'is_create_org', 'invitation_code']);
+        
+        // When invitation_code is present, use registration flow
+        if (!empty($additionalParams['invitation_code']) && !isset($additionalParams['prompt'])) {
+            $additionalParams['prompt'] = 'create';
+        }
         
         try {
             $result = $this->kindeClient->login($additionalParams);
@@ -110,7 +115,7 @@ class KindeAuthController extends Controller
      */
     public function register(Request $request): RedirectResponse
     {
-        $additionalParams = $request->only(['org_code', 'org_name', 'is_create_org']);
+        $additionalParams = $request->only(['org_code', 'org_name', 'is_create_org', 'invitation_code']);
         
         try {
             $result = $this->kindeClient->register($additionalParams);

--- a/lib/Frameworks/Symfony/KindeAuthController.php
+++ b/lib/Frameworks/Symfony/KindeAuthController.php
@@ -38,6 +38,16 @@ class KindeAuthController extends AbstractController
         if ($request->query->has('is_create_org')) {
             $additionalParams['is_create_org'] = $request->query->get('is_create_org');
         }
+        if ($request->query->has('invitation_code')) {
+            $invitationCode = $request->query->get('invitation_code');
+            if (!empty($invitationCode)) {
+                $additionalParams['invitation_code'] = $invitationCode;
+                // When invitation_code is present, use registration flow
+                if (!isset($additionalParams['prompt'])) {
+                    $additionalParams['prompt'] = 'create';
+                }
+            }
+        }
         
         try {
             $result = $this->kindeClient->login($additionalParams);
@@ -112,6 +122,12 @@ class KindeAuthController extends AbstractController
         }
         if ($request->query->has('is_create_org')) {
             $additionalParams['is_create_org'] = $request->query->get('is_create_org');
+        }
+        if ($request->query->has('invitation_code')) {
+            $invitationCode = $request->query->get('invitation_code');
+            if (!empty($invitationCode)) {
+                $additionalParams['invitation_code'] = $invitationCode;
+            }
         }
         
         try {

--- a/lib/Sdk/Enums/AdditionalParameters.php
+++ b/lib/Sdk/Enums/AdditionalParameters.php
@@ -15,6 +15,7 @@ class AdditionalParameters
         'plan_interest' => 'string',
         'pricing_table_key' => 'string',
         'prompt' => 'string',
-        'redirect_uri' => 'string'
+        'redirect_uri' => 'string',
+        'invitation_code' => 'string'
     ];
 }

--- a/lib/Sdk/OAuth2/AuthorizationCode.php
+++ b/lib/Sdk/OAuth2/AuthorizationCode.php
@@ -44,6 +44,12 @@ class AuthorizationCode
             'supports_reauth' => 'true',
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
+        
+        // Auto-derive is_invitation when invitation_code is present
+        if (!empty($mergedAdditionalParameters['invitation_code'])) {
+            $mergedAdditionalParameters['is_invitation'] = 'true';
+        }
+        
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);
         if (!headers_sent()) {
             exit(header('Location: ' . $clientSDK->authorizationEndpoint . '?' . http_build_query($searchParams)));

--- a/lib/Sdk/OAuth2/PKCE.php
+++ b/lib/Sdk/OAuth2/PKCE.php
@@ -43,6 +43,12 @@ class PKCE
             'state' => $state
         ];
         $mergedAdditionalParameters = Utils::addAdditionalParameters($clientSDK->additionalParameters, $additionalParameters);
+        
+        // Auto-derive is_invitation when invitation_code is present
+        if (!empty($mergedAdditionalParameters['invitation_code'])) {
+            $mergedAdditionalParameters['is_invitation'] = 'true';
+        }
+        
         $searchParams = array_merge($searchParams, $mergedAdditionalParameters);
         $this->storage->setCodeVerifier($challenge['codeVerifier']);
 


### PR DESCRIPTION
## Changes

- Added invitation_code as a supported additional parameter
- Auto-derives is_invitation=true when invitation_code is provided
- Framework Integrations (Laravel, CodeIgniter, Symfony):
- Login/register endpoints now accept invitation_code query parameter
- Automatically sets prompt=create for invitation flows to show registration screen

## Files Changed

- lib/Sdk/Enums/AdditionalParameters.php
- lib/Sdk/OAuth2/PKCE.php
- lib/Sdk/OAuth2/AuthorizationCode.php
- lib/Frameworks/Laravel/Controllers/KindeAuthController.php
- lib/Frameworks/CodeIgniter/KindeAuthController.php
- lib/Frameworks/Symfony/KindeAuthController.php