### PR TITLE
fix(deps): upgrade firebase/php-jwt to v7.0.5 with required migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^7.3",
     "guzzlehttp/psr7": "^1.7 || ^2.0",
-    "firebase/php-jwt": "^6.10"
+    "firebase/php-jwt": "^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0 || ^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a24fe151d519e2f1138318b4f348db8",
+    "content-hash": "4720608b2c70a97c21ff16d04b4be12e",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -25,6 +25,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -64,10 +65,10 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/playground/codeigniter/composer.json
+++ b/playground/codeigniter/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.1",
         "codeigniter4/framework": "^4.0",
-        "firebase/php-jwt": "^6.11",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.9"
     },
     "require-dev": {

--- a/playground/codeigniter/composer.lock
+++ b/playground/codeigniter/composer.lock
@@ -82,16 +82,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -99,6 +99,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -138,10 +139,10 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/playground/laravel/composer.json
+++ b/playground/laravel/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "firebase/php-jwt": "^6.11",
+        "firebase/php-jwt": "^7.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1"
     },

--- a/playground/laravel/composer.lock
+++ b/playground/laravel/composer.lock
@@ -512,16 +512,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -529,6 +529,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -568,10 +569,10 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/playground/symfony/composer.json
+++ b/playground/symfony/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "firebase/php-jwt": "^6.11",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.9",
         "symfony/console": "7.3.*",
         "symfony/dotenv": "7.3.*",

--- a/playground/symfony/composer.lock
+++ b/playground/symfony/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -25,6 +25,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -64,10 +65,10 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/tests/Support/MockTokenGenerator.php
+++ b/tests/Support/MockTokenGenerator.php
@@ -10,7 +10,7 @@ use Firebase\JWT\JWT;
  */
 class MockTokenGenerator
 {
-    private const SECRET_KEY = 'test-secret-key-for-unit-tests';
+    private const SECRET_KEY = 'test-secret-key-for-unit-tests!!';
     private const ALGORITHM = 'HS256';
     private const KEY_ID = 'test-key-id';
 


### PR DESCRIPTION
## Summary

This PR upgrades `firebase/php-jwt` from `^6.x` to `^7.0` (locked to **v7.0.5**) and includes the **required migration** changes that make #109 unsafe to merge as-is.

Supersedes / closes #109.

---

## Why #109 cannot be merged directly

PR #109 bumps to `v7.0.0` but misses a required migration fix:

### Breaking change in v7.0.0 - HMAC key size validation

`firebase/php-jwt` v7.0.0 added strict minimum key-size enforcement ([commit 6b80341](https://github.com/googleapis/php-jwt/commit/6b80341bf57838ea2d011487917337901cd71576)):

- **HS256** requires a key of **at least 256 bits (32 bytes)**
- **HS384** requires ≥ 384 bits (48 bytes)
- **HS512** requires ≥ 512 bits (64 bytes)

The existing test helper `MockTokenGenerator::SECRET_KEY = 'test-secret-key-for-unit-tests'` is **30 bytes (240 bits)**, which is below the HS256 minimum. Every `JWT::encode` / `JWT::decode` call in the test suite would throw `DomainException: Provided key is too short`.

---

## Changes in this PR

### Migration fix
| File | Change |
|---|---|
| `tests/Support/MockTokenGenerator.php` | Extend `SECRET_KEY` to 32 bytes: `'test-secret-key-for-unit-tests!!'` |

### Dependency bump (to v7.0.5 — latest, not just v7.0.0)
| File | Change |
|---|---|
| `composer.json` | `^6.10` → `^7.0` |
| `composer.lock` | pinned to `v7.0.5` |
| `playground/codeigniter/composer.json` | `^6.11` → `^7.0` |
| `playground/codeigniter/composer.lock` | pinned to `v7.0.5` |
| `playground/laravel/composer.json` | `^6.11` → `^7.0` |
| `playground/laravel/composer.lock` | pinned to `v7.0.5` |
| `playground/symfony/composer.json` | `^6.11` → `^7.0` |
| `playground/symfony/composer.lock` | pinned to `v7.0.5` |

---

## Why v7.0.5 and not v7.0.0?

v7.0.5 includes additional fixes on top of v7.0.0 that are directly relevant to this SDK:

| Version | Fix |
|---|---|
| v7.0.2 | Add key length validation for EC keys |
| v7.0.4 | Use `urlsafeB64Decode` consistently (fixes token parsing edge cases) |
| **v7.0.5** | **Fix RSA from JWK sometimes returning empty instance** — directly impacts `JWK::parseKeySet()` used in `Utils::parseJWT()` |

---

## Security context

This upgrade fixes **CVE-2025-45769** (CVSS 2.7 Low): weak encryption in `php-jwt` v6.x.

The SDK's JWT usage (`Utils::parseJWT` → `JWT::decode` + `JWK::parseKeySet`) is fully compatible with v7.x - the public API (`JWT::decode`, `JWT::encode`, `JWK::parseKeySet`, `Key`) has not changed.

---

## Note on `composer.lock` content-hashes

The `content-hash` entries in `playground/symfony/composer.lock`, `playground/codeigniter/composer.lock`, and `playground/laravel/composer.lock` will need to be regenerated by running `composer update firebase/php-jwt` in each playground directory (composer is not available in the CI environment at PR creation time). The main `composer.lock` content-hash has been updated correctly.