### PR TITLE
fix(deps): upgrade laravel-vite-plugin to ^3.0.1 with required Vite 8 migration

### DIFF
--- a/playground/laravel/package.json
+++ b/playground/laravel/package.json
@@ -10,8 +10,8 @@
         "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^1.2.0",
+        "laravel-vite-plugin": "^3.0.1",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.2.4"
+        "vite": "^8.0.0"
     }
 }


### PR DESCRIPTION
## Summary

This PR is a clean replacement for #102 (Renovate's automatic PR), which correctly identified the need to upgrade `laravel-vite-plugin` but was **incomplete** - it left `vite` at `^6.2.4` while `laravel-vite-plugin@3.x` requires `vite ^8.0.0` as a peer dependency, which would result in a broken install.

## Changes

| File | Change |
|---|---|
| `playground/laravel/package.json` | `laravel-vite-plugin` `^1.2.0` → `^3.0.1` |
| `playground/laravel/package.json` | `vite` `^6.2.4` → `^8.0.0` |

## Why vite must also be bumped

`laravel-vite-plugin@3.x` declares `peerDependencies: { "vite": "^8.0.0" }`. Installing v3 with Vite 6 active would produce a peer dependency conflict and broken builds.

## Migration Assessment (1.x → 3.x)

### v1.x → v2.x
- **Change**: Adds Vite 7 support
- **Breaking changes**: None (no API changes, no code migration required)

### v2.x → v3.x  
- **Change**: Adds Vite 8 support
- **Only breaking change**: If you use `import.meta.glob` for static assets in your JS entry point, you must move those to the new `assets` config option in `vite.config.js`:

```js
// Before (v2.x)
// resources/js/app.js
import.meta.glob(['../images/**', '../favicons/**'])

// After (v3.x)
// vite.config.js
laravel({
    input: ['resources/css/app.css', 'resources/js/app.js'],
    refresh: true,
+   assets: ['../images/**', '../favicons/**'],
})
```

### Impact on this repo

**No `vite.config.js` changes needed.** The playground's `vite.config.js` does **not** use `import.meta.glob` for static assets:

```js
// playground/laravel/vite.config.js -no changes needed ✅
export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            refresh: true,
        }),
        tailwindcss(),
    ],
});
```

### `@tailwindcss/vite` compatibility

`@tailwindcss/vite ^4.0.0` already declares `peerDependencies: { "vite": "^5.2.0 || ^6 || ^7 || ^8" }` - it supports Vite 8 without a version bump.

## Why PR #102 cannot be merged as-is

Merging #102 with `vite` still at `^6.2.4` would cause an npm peer dependency conflict. The plugin would either refuse to install or produce unexpected behavior at runtime.

---

Supersedes/closes: #102