### PR TITLE
fix: core tests fixed

### DIFF
--- a/lib/KindeClientSDK.php
+++ b/lib/KindeClientSDK.php
@@ -351,6 +351,10 @@ class KindeClientSDK
 
         $claims = self::getClaims($tokenType);
 
+        if (!is_array($claims)) {
+            $claims = [];
+        }
+
         if (!array_key_exists($keyName, $claims)) {
             error_log("The value of '{$keyName}' claimed does not exist in your token");
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -36,7 +36,7 @@
         </testsuite>
     </testsuites>
     
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">lib</directory>
         </include>
@@ -46,12 +46,8 @@
             <directory suffix=".php">tests</directory>
             <directory suffix=".php">examples</directory>
         </exclude>
-        <report>
-            <html outputDirectory="coverage/html"/>
-            <clover outputFile="coverage/clover.xml"/>
-        </report>
-    </coverage>
-    
+    </source>
+
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="KINDE_DOMAIN" value="https://test-domain.kinde.com"/>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -39,6 +39,18 @@ fi
 mkdir -p coverage
 mkdir -p logs
 
+# Detect whether a code coverage driver (Xdebug or PCOV) is available.
+# PHPUnit 13 aborts with "No tests executed!" if coverage is requested without
+# a driver, so we only add coverage flags when one is present.
+COVERAGE_AVAILABLE=0
+if php -r 'exit((extension_loaded("pcov") || extension_loaded("xdebug")) ? 0 : 1);' >/dev/null 2>&1; then
+    COVERAGE_AVAILABLE=1
+    # Xdebug needs coverage mode explicitly enabled.
+    export XDEBUG_MODE=coverage
+else
+    print_warning "No code coverage driver (Xdebug or PCOV) found; running tests without coverage."
+fi
+
 # Function to run tests
 run_tests() {
     local suite=$1
@@ -46,7 +58,12 @@ run_tests() {
     
     print_status "Running $suite tests..."
     
-    if php vendor/bin/phpunit --testsuite="$suite" --coverage-html="coverage/${suite// /_}" --coverage-clover="coverage/${suite// /_}_clover.xml" > "$output_file" 2>&1; then
+    local coverage_flags=()
+    if [ "$COVERAGE_AVAILABLE" -eq 1 ]; then
+        coverage_flags=(--coverage-html="coverage/${suite// /_}" --coverage-clover="coverage/${suite// /_}_clover.xml")
+    fi
+
+    if php vendor/bin/phpunit --testsuite="$suite" "${coverage_flags[@]}" > "$output_file" 2>&1; then
         print_success "$suite tests passed"
         return 0
     else
@@ -59,7 +76,12 @@ run_tests() {
 run_all_tests() {
     print_status "Running all tests..."
     
-    if php vendor/bin/phpunit --coverage-html="coverage/all" --coverage-clover="coverage/all_clover.xml" > "logs/all_test_results.txt" 2>&1; then
+    local coverage_flags=()
+    if [ "$COVERAGE_AVAILABLE" -eq 1 ]; then
+        coverage_flags=(--coverage-html="coverage/all" --coverage-clover="coverage/all_clover.xml")
+    fi
+
+    if php vendor/bin/phpunit "${coverage_flags[@]}" > "logs/all_test_results.txt" 2>&1; then
         print_success "All tests passed"
         return 0
     else

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -63,7 +63,7 @@ run_tests() {
         coverage_flags=(--coverage-html="coverage/${suite// /_}" --coverage-clover="coverage/${suite// /_}_clover.xml")
     fi
 
-    if php vendor/bin/phpunit --testsuite="$suite" "${coverage_flags[@]}" > "$output_file" 2>&1; then
+    if php -d memory_limit=-1 vendor/bin/phpunit --testsuite="$suite" "${coverage_flags[@]}" > "$output_file" 2>&1; then
         print_success "$suite tests passed"
         return 0
     else
@@ -81,7 +81,7 @@ run_all_tests() {
         coverage_flags=(--coverage-html="coverage/all" --coverage-clover="coverage/all_clover.xml")
     fi
 
-    if php vendor/bin/phpunit "${coverage_flags[@]}" > "logs/all_test_results.txt" 2>&1; then
+    if php -d memory_limit=-1 vendor/bin/phpunit "${coverage_flags[@]}" > "logs/all_test_results.txt" 2>&1; then
         print_success "All tests passed"
         return 0
     else

--- a/tests/Support/KindeTestCase.php
+++ b/tests/Support/KindeTestCase.php
@@ -78,6 +78,11 @@ abstract class KindeTestCase extends TestCase
             $cookieName = 'kinde_' . $key;
             unset($_COOKIE[$cookieName]);
         }
+
+        // The JWKS cache is namespaced by md5(jwksUrl) when a URL is configured,
+        // so the bare key above does not cover it.
+        $namespacedJwks = 'kinde_' . StorageEnums::JWKS_CACHE . '_' . md5(self::TEST_DOMAIN . '/.well-known/jwks.json');
+        unset($_COOKIE[$namespacedJwks]);
     }
 
     /**
@@ -140,7 +145,7 @@ abstract class KindeTestCase extends TestCase
                 ],
             ],
         ];
-        Storage::setCachedJwks($jwks, 3600);
+        Storage::setCachedJwks($jwks, 3600, self::TEST_DOMAIN . '/.well-known/jwks.json');
     }
 
     /**

--- a/tests/Support/KindeTestCase.php
+++ b/tests/Support/KindeTestCase.php
@@ -80,9 +80,14 @@ abstract class KindeTestCase extends TestCase
         }
 
         // The JWKS cache is namespaced by md5(jwksUrl) when a URL is configured,
-        // so the bare key above does not cover it.
-        $namespacedJwks = 'kinde_' . StorageEnums::JWKS_CACHE . '_' . md5(self::TEST_DOMAIN . '/.well-known/jwks.json');
-        unset($_COOKIE[$namespacedJwks]);
+        // so the bare key above does not cover it. Clear every namespaced JWKS
+        // cache cookie regardless of which URL it was derived from.
+        $namespacedPrefix = 'kinde_' . StorageEnums::JWKS_CACHE . '_';
+        foreach (array_keys($_COOKIE) as $cookieName) {
+            if (strpos($cookieName, $namespacedPrefix) === 0) {
+                unset($_COOKIE[$cookieName]);
+            }
+        }
     }
 
     /**

--- a/tests/Unit/HasFeatureFlagsTest.php
+++ b/tests/Unit/HasFeatureFlagsTest.php
@@ -175,7 +175,7 @@ class HasFeatureFlagsTest extends KindeTestCase
                 ],
             ],
         ];
-        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE] = json_encode([
+        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE . '_' . md5(self::TEST_DOMAIN . '/.well-known/jwks.json')] = json_encode([
             'jwks' => $jwks,
             'expires_at' => time() + 3600,
         ]);

--- a/tests/Unit/HasPermissionsTest.php
+++ b/tests/Unit/HasPermissionsTest.php
@@ -170,7 +170,7 @@ class HasPermissionsTest extends KindeTestCase
                 ],
             ],
         ];
-        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE] = json_encode([
+        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE . '_' . md5(self::TEST_DOMAIN . '/.well-known/jwks.json')] = json_encode([
             'jwks' => $jwks,
             'expires_at' => time() + 3600,
         ]);

--- a/tests/Unit/HasRolesTest.php
+++ b/tests/Unit/HasRolesTest.php
@@ -161,7 +161,7 @@ class HasRolesTest extends KindeTestCase
                 ],
             ],
         ];
-        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE] = json_encode([
+        $_COOKIE['kinde_' . StorageEnums::JWKS_CACHE . '_' . md5(self::TEST_DOMAIN . '/.well-known/jwks.json')] = json_encode([
             'jwks' => $jwks,
             'expires_at' => time() + 3600,
         ]);

--- a/tests/Unit/StorageTest.php
+++ b/tests/Unit/StorageTest.php
@@ -38,7 +38,8 @@ class StorageTest extends KindeTestCase
 
     protected function seedJwksCache(): void
     {
-        Storage::setJwksUrl('https://example.com/jwks.json');
+        $jwksUrl = 'https://example.com/jwks.json';
+        Storage::setJwksUrl($jwksUrl);
         $secret = MockTokenGenerator::getSecretKey();
         $encodedSecret = rtrim(strtr(base64_encode($secret), '+/', '-_'), '=');
         $jwks = [
@@ -52,7 +53,7 @@ class StorageTest extends KindeTestCase
                 ],
             ],
         ];
-        Storage::setCachedJwks($jwks, 3600);
+        Storage::setCachedJwks($jwks, 3600, $jwksUrl);
     }
 
     // =========================================================================


### PR DESCRIPTION
fix: make PHPUnit 13 suite runnable without a coverage driver + correct JWKS cache key in tests

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
