### PR TITLE
fix(renovate): group guzzlehttp/guzzle and guzzlehttp/psr7 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "guzzlehttp/guzzle",
+        "guzzlehttp/psr7"
+      ],
+      "groupName": "guzzlehttp packages"
+    }
   ]
 }


### PR DESCRIPTION
Guzzle 7.12.1 requires guzzlehttp/psr7 ^2.12.1, but psr7 is a root requirement locked at 2.11.0. Renovate's single-package update can't bump it, so artifact regeneration fails. Grouping them updates both together. Merge this before PR #156 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
